### PR TITLE
Replace pkg_resources with importlib

### DIFF
--- a/riptide_engine_docker/assets.py
+++ b/riptide_engine_docker/assets.py
@@ -1,5 +1,13 @@
-import pkg_resources
+import atexit
+import importlib.resources
+
+from contextlib import ExitStack
 
 
 def riptide_engine_docker_assets_dir():
-    return pkg_resources.resource_filename(__name__, 'assets')
+    file_manager = ExitStack()
+    atexit.register(file_manager.close)
+    package_name = __name__.split(".")[0]
+    ref = importlib.resources.files(package_name) / 'assets'
+    path = file_manager.enter_context(importlib.resources.as_file(ref))
+    return path


### PR DESCRIPTION
Since `pkg_resources` has been deprecated in favor of `importlib` this PR replaces the old API with the new one.

As a reference the following migration guides were used:
- [importlib.metadata](https://importlib-metadata.readthedocs.io/en/latest/migration.html)
- [importlib.resources](https://importlib-resources.readthedocs.io/en/latest/migration.html)