### PR TITLE
Allow disabling original image entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "riptide-engine-docker"
-version = "0.9.0"
+version = "0.9.1"
 description = "Tool to manage development environments for web applications using containers - Docker Implementation"
 readme = "README.rst"
 requires-python = ">=3.8"


### PR DESCRIPTION
Requires https://github.com/theCapypara/riptide-lib/pull/85

If "ignore_original_entrypoint" is set and defined in either a Command or Service, the original entrypoint is not executed.